### PR TITLE
Fix: remove redundant ORDER BY in vector search queries

### DIFF
--- a/src/mem0_falkordb/graph_memory.py
+++ b/src/mem0_falkordb/graph_memory.py
@@ -474,8 +474,6 @@ class MemoryGraph:
             YIELD node, score
             WITH node, score
             WHERE {where_str}
-            WITH node, score
-            ORDER BY score DESC
             LIMIT $limit
             RETURN id(node) AS node_id, node.name AS node_name, score
             """
@@ -748,7 +746,6 @@ class MemoryGraph:
         YIELD node, score
         WITH node, score
         WHERE {where_str}
-        ORDER BY score DESC
         LIMIT 1
         RETURN id(node) AS node_id
         """


### PR DESCRIPTION
## Problem

`m.add()` fails with:
```
redis.exceptions.ResponseError: Invalid input 'D': expected OR
  ORDER BY score DESC
```

Some FalkorDB versions don't support `ORDER BY ... DESC` after a `YIELD` from `db.idx.vector.queryNodes`.

## Fix

Removed the redundant `ORDER BY score DESC` from both `_search_graph_db` and `_search_node_by_embedding`. The `db.idx.vector.queryNodes` procedure already returns results sorted by cosine similarity score in descending order, so the explicit `ORDER BY` was unnecessary.
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a performance issue by removing redundant `ORDER BY` clauses from vector search queries in the graph database interaction logic. This optimization aims to improve query execution efficiency.

#### Key Changes
- Removed the explicit `ORDER BY score DESC` clause from the `_search_graph_db` function's query.
- Removed the explicit `ORDER BY score DESC` clause from the `_search_node_by_embedding` function's query.
- These `ORDER BY` clauses were redundant as the `YIELD node, score` already provides results ordered by score in descending order for vector search operations.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Churn       | 3 (100.0%)    |
| Total Changes | 3             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>