### PR TITLE
new release 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0-falkordb"
-version = "0.3.1"
+version = "0.3.2"
 description = "FalkorDB graph store plugin for Mem0"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "mem0-falkordb"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "falkordb" },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR prepares for a new release of the `mem0-falkordb` package by updating its version and adjusting a dependency constraint.

#### Key Changes
- Updated the `mem0-falkordb` package version from `0.3.1` to `0.3.2` in `pyproject.toml` and `uv.lock`.
- Modified the `exceptiongroup` dependency constraint in `uv.lock` to apply for `python_full_version < '3.11'` instead of `< '3.13'`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Rework   | 3 (100.0%)    |
| Total Changes | 3             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>