### PR TITLE
Delete License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,3 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
-
-Apache-2.0


### PR DESCRIPTION
Removed license section from README.
 
 **PR Summary by Typo**
------------

#### Overview
This PR removes the redundant "License" section from the `README.md` file.

#### Key Changes
- Deleted the "License" heading and the "Apache-2.0" entry from `README.md`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 3 (100.0%)    |
| Total Changes | 3          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>