### PR TITLE
Fix: move LIMIT after RETURN for FalkorDB compatibility

### DIFF
--- a/src/mem0_falkordb/graph_memory.py
+++ b/src/mem0_falkordb/graph_memory.py
@@ -472,8 +472,8 @@ class MemoryGraph:
             YIELD node, score
             WITH node, score
             WHERE {where_str}
-            LIMIT {int(limit)}
             RETURN id(node) AS node_id, node.name AS node_name, score
+            LIMIT {int(limit)}
             """
 
             params = {
@@ -743,8 +743,8 @@ class MemoryGraph:
         YIELD node, score
         WITH node, score
         WHERE {where_str}
-        LIMIT 1
         RETURN id(node) AS node_id
+        LIMIT 1
         """
 
         params = {


### PR DESCRIPTION
FalkorDB's Cypher parser does not support `LIMIT` between `WHERE` and `RETURN` clauses. This causes:

```
redis.exceptions.ResponseError: errMsg: Invalid input 'I': expected LOAD CSV
```

**Fix:** Move `LIMIT` to after `RETURN` in both `_search_graph_db` and `_search_node_by_embedding` vector queries.

Tested against live FalkorDB — all unit and e2e tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
 **PR Summary by Typo**
------------

#### Overview
This PR fixes a compatibility issue with FalkorDB by adjusting the placement of the `LIMIT` clause in Cypher queries.

#### Key Changes
- Modified `_search_graph_db` and `_search_node_by_embedding` functions in `src/mem0_falkordb/graph_memory.py`.
- Relocated the `LIMIT` clause in two Cypher queries to appear after the `RETURN` statement, ensuring correct syntax for FalkorDB.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Rework      | 2 (100.0%)    |
| Total Changes | 2             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized search query execution for graph database operations to ensure correct result limiting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->