### PR TITLE
Remove editable source for mem0-falkordb

### DIFF
--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -11,8 +11,5 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
-[tool.uv.sources]
-mem0-falkordb = { path = "..", editable = true }
-
 [tool.uv]
 package = false


### PR DESCRIPTION
Removed editable source for mem0-falkordb.
 
 **PR Summary by Typo**
------------

#### Overview
This PR removes the editable source configuration for `mem0-falkordb` from the `pyproject.toml` file. This change ensures the project no longer uses a local, editable version of this dependency.

#### Key Changes
- Removed the `[tool.uv.sources]` section and its entry for `mem0-falkordb` from `demo/pyproject.toml`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 3 (100.0%)    |
| Total Changes | 3         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed local development dependency configuration, simplifying the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->